### PR TITLE
fix: homepage tiles for mobile screens

### DIFF
--- a/src/lib/components/hero.svelte
+++ b/src/lib/components/hero.svelte
@@ -42,12 +42,12 @@
 		<picture class="w-full">
 			<source media="(min-width: 2000px)" srcset="./big-hero-new.svg" />
 			<source media="(min-width: 650px)" srcset="./hero-101.svg" />
-			<source media="(min-width: 390px)" srcset="./small-hero.svg" />
+			<source media="(min-width: 360px)" srcset="./small-hero.svg" />
 			<img alt="hero svg" class="w-full" src="./hero.svg" />
 		</picture>
 
 		<div
-			class="flex max-w-[1391px] flex-col items-center text-center text-primary-600 w-3/5 sm:w-4/5"
+			class="flex max-w-[1391px] flex-col items-center text-center text-primary-600 w-full px-6 md:px-16"
 		>
 			<span class="text-3xl font-semibold md:text-5xl lg:font-bold lg:text-6xl">
 				A Decentralised Container Registry
@@ -84,88 +84,85 @@
 		</div>
 	</div>
 
-	<div
-		class="grid w-3/4 lg:w-full max-w-[1100px] grid-cols-2 place-items-center gap-2 pt-10 pb-20 px-4 md:w-3/5 md:min-w-[600px]
-		md:grid-cols-3 lg:gap-8 lg:grid-cols-5"
-	>
-		<div class="col-span-2 pb-9 md:col-span-3 lg:col-span-5">
-			<div
-				class="flex flex-col items-center justify-center text-center 
-				text-base text-primary-600 lg:text-lg"
-			>
-				<span>
-					Browse, Pull, Push and Share 100s of container images by open source projects, software
-					vendors and communities.</span
-				>
-			</div>
+	<div class="flex flex-col justify-center items-center gap-9 pt-10 pb-20">
+		<div
+			class="flex flex-col items-center justify-center text-center text-base text-primary-600 lg:text-lg px-9"
+		>
+			<span>
+				Browse, Pull, Push and Share 100s of container images by open source projects, software
+				vendors and communities.
+			</span>
 		</div>
-		<RepoBox styles="bg-[#081c45]" href="#">
-			<StorjIcon />
-		</RepoBox>
 
-		<RepoBox>
-			<div class="h-full w-full flex justify-center items-center">
-				<img src="./IPFS_ad.png" alt="" width="150px" />
-			</div>
-		</RepoBox>
+		<div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-3 md:gap-6 lg:gap-9 max-w-6xl">
+			<RepoBox styles="bg-[#081c45]" href="#">
+				<StorjIcon />
+			</RepoBox>
 
-		<RepoBox href="#" styles="bg-stone-700">
-			<IexecIcon />
-		</RepoBox>
-		<RepoBox href="#" styles="bg-[#ce4748]">
-			<AkashIcon />
-		</RepoBox>
+			<RepoBox>
+				<div class="h-full w-full flex justify-center items-center">
+					<img src="./IPFS_ad.png" alt="" width="150px" />
+				</div>
+			</RepoBox>
 
-		<RepoBox href="#" styles="bg-primary-600">
-			<div><img alt="nodejs" src="./solanaLogo.png" width="120px" /></div>
-		</RepoBox>
+			<RepoBox href="#" styles="bg-stone-700">
+				<IexecIcon />
+			</RepoBox>
+			<RepoBox href="#" styles="bg-[#ce4748]">
+				<AkashIcon />
+			</RepoBox>
 
-		<RepoBox href="#">
-			<div><img alt="nginx" src="./nginx.png" width="100px" /></div>
-		</RepoBox>
+			<RepoBox href="#" styles="bg-primary-600">
+				<div><img alt="nodejs" src="./solanaLogo.png" width="120px" /></div>
+			</RepoBox>
 
-		<RepoBox href="#">
-			<div><img alt="nginx" src="./busybox1.png" width="50px" /></div>
-			<span class="text-lg font-semibold">BusyBox</span>
-		</RepoBox>
+			<RepoBox href="#">
+				<div><img alt="nginx" src="./nginx.png" width="100px" /></div>
+			</RepoBox>
 
-		<RepoBox href="#">
-			<div><img alt="nginx" src="./library-alpine-logo.png" width="50px" /></div>
-			<span class="text-xl font-semibold text-blue-800">Alpine</span>
-		</RepoBox>
+			<RepoBox href="#">
+				<div><img alt="nginx" src="./busybox1.png" width="50px" /></div>
+				<span class="text-lg font-semibold">BusyBox</span>
+			</RepoBox>
 
-		<RepoBox href="#">
-			<div><MongoIcon /></div>
-		</RepoBox>
+			<RepoBox href="#">
+				<div><img alt="nginx" src="./library-alpine-logo.png" width="50px" /></div>
+				<span class="text-xl font-semibold text-blue-800">Alpine</span>
+			</RepoBox>
 
-		<RepoBox href="#">
-			<div><img alt="nodejs" src="./Redis-Logo.png" width="120px" /></div>
-			<span class="text-lg font-semibold tracking-wider text-primary-600" />
-		</RepoBox>
+			<RepoBox href="#">
+				<div><MongoIcon /></div>
+			</RepoBox>
 
-		<RepoBox href="#">
-			<div><img alt="nodejs" src="./nodejs.png" width="30px" /></div>
-			<span class="text-lg font-semibold tracking-wider text-primary-600">node</span>
-		</RepoBox>
+			<RepoBox href="#">
+				<div><img alt="nodejs" src="./Redis-Logo.png" width="120px" /></div>
+				<span class="text-lg font-semibold tracking-wider text-primary-600" />
+			</RepoBox>
 
-		<RepoBox href="#">
-			<div><img alt="nodejs" src="./ubuntu-logo32.png" width="30px" /></div>
-			<span class="text-lg font-semibold tracking-wider text-primary-600">ubuntu</span>
-		</RepoBox>
+			<RepoBox href="#">
+				<div><img alt="nodejs" src="./nodejs.png" width="30px" /></div>
+				<span class="text-lg font-semibold tracking-wider text-primary-600">node</span>
+			</RepoBox>
 
-		<RepoBox href="#">
-			<div><img alt="nodejs" src="./traefik-logo.png" width="30px" /></div>
-			<span class="text-lg font-semibold tracking-wider text-primary-600">traefik</span>
-		</RepoBox>
+			<RepoBox href="#">
+				<div><img alt="nodejs" src="./ubuntu-logo32.png" width="30px" /></div>
+				<span class="text-lg font-semibold tracking-wider text-primary-600">ubuntu</span>
+			</RepoBox>
 
-		<RepoBox href="#">
-			<div><img alt="nodejs" src="./python-logo-only.png" width="30px" /></div>
-			<span class="text-lg font-semibold tracking-wider text-primary-600">python</span>
-		</RepoBox>
+			<RepoBox href="#">
+				<div><img alt="nodejs" src="./traefik-logo.png" width="30px" /></div>
+				<span class="text-lg font-semibold tracking-wider text-primary-600">traefik</span>
+			</RepoBox>
 
-		<RepoBox href="#">
-			<div><img alt="nodejs" src="./library-httpd-logo.png" width="50px" /></div>
-			<span class="text-lg font-semibold tracking-wider text-primary-600">httpd</span>
-		</RepoBox>
+			<RepoBox href="#">
+				<div><img alt="nodejs" src="./python-logo-only.png" width="30px" /></div>
+				<span class="text-lg font-semibold tracking-wider text-primary-600">python</span>
+			</RepoBox>
+
+			<RepoBox href="#">
+				<div><img alt="nodejs" src="./library-httpd-logo.png" width="50px" /></div>
+				<span class="text-lg font-semibold tracking-wider text-primary-600">httpd</span>
+			</RepoBox>
+		</div>
 	</div>
 </Card>

--- a/src/lib/components/high-level-architecture.svelte
+++ b/src/lib/components/high-level-architecture.svelte
@@ -4,7 +4,7 @@
 </script>
 
 <Card styles="bg-primary-100 block py-12 lg:py-20 flex flex-col gap-6">
-	<div class="flex w-1/2 lg:w-full flex-col justify-center lg:max-w-2xl items-center">
+	<div class="flex px-6 w-full flex-col justify-center max-w-2xl items-center">
 		<span
 			class="text-primary-600 text-center whitespace-nowrap font-bold pb-6 text-3xl lg:text-5xl">
 			High Level Architecture

--- a/src/lib/components/overview.svelte
+++ b/src/lib/components/overview.svelte
@@ -5,13 +5,13 @@
 
 <Card styles="bg-primary-50 py-12">
 	<div class="w-full h-full">
-		<div class="px-6 w-full flex justify-center items-center flex-col xl:flex-row my-3 lg:my-28">
+		<div class="px-6 md:px-9 w-full flex justify-center items-center flex-col xl:flex-row my-3 lg:my-28">
 			<div class="w-80 md:w-fit">
 				<picture>
 					<img src="overview.svg" alt="Operations" width="600px" />
 				</picture>
 			</div>
-			<div class="w-3/5 mx-8 flex justify-center flex-col lg:max-w-2xl">
+			<div class="w-full mx-8 flex justify-center flex-col max-w-2xl">
 				<span
 					class=" text-primary-600 text-center whitespace-nowrap font-semibold pb-4 text-3xl lg:text-5xl">
 					Overview
@@ -60,7 +60,7 @@
 		<div
 			class="px-6 w-full flex justify-center items-center flex-col-reverse xl:flex-row my-2 lg:my-28"
 		>
-			<div class="w-3/5 mx-8 flex justify-center flex-col lg:max-w-2xl">
+			<div class="w-full mx-8 flex justify-center flex-col max-w-2xl">
 				<span
 					class="text-primary-600 text-center whitespace-nowrap font-semibold pb-4 text-3xl lg:text-5xl">
 					Collaborations
@@ -115,7 +115,7 @@
 					<img src="man-arrow-up.svg" alt="Storage" width="600px" />
 				</picture>
 			</div>
-			<div class="w-3/5 mx-8 flex justify-center flex-col lg:max-w-2xl">
+			<div class="w-full mx-8 flex justify-center flex-col max-w-2xl">
 				<div class="flex justify-center items-center text-center">
 					<span
 						class="text-primary-600 text-center whitespace-nowrap font-semibold pb-4 text-3xl lg:text-5xl">

--- a/src/lib/components/repo-box.svelte
+++ b/src/lib/components/repo-box.svelte
@@ -3,10 +3,11 @@
     export let href = '';
 </script>
 
+<!-- lg:h-24 lg:w-[170px] -->
 <a
 	href={href}
 	class="{styles} flex items-center justify-center border border-slate-800 rounded-sm delay-100 ease-in-out 
-	hover:no-underline hover:shadow-2xl hover:shadow-primary-200 h-20 w-[160px] md:h-24 md:w-[170px]"
+	hover:no-underline hover:shadow-2xl hover:shadow-primary-200 h-20 w-[160px] lg:h-24 lg:w-[170px]"
 >
 	<slot />
 </a>

--- a/src/lib/footer.svelte
+++ b/src/lib/footer.svelte
@@ -43,7 +43,7 @@
 			<div class="ml-5">
 				<a
 					href="#top"
-					class="-ml-1 flex cursor-pointer items-center hover:no-underline hover:opacity-80"
+					class="-ml-3 flex cursor-pointer items-center hover:no-underline hover:opacity-80"
 				>
 					<Logo type="light" />
 				</a>


### PR DESCRIPTION
### Motivation & Context:
Throughout the process of standard screen sizing, the tiles on home page got messed up for mobile screens. This PR fixes that problem along with the width of the paragraphs which was kind of weird for mobile screens

### Description:
container image tiles for mobile screens

### Types of Changes:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### PR Checklist:

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I've read the CONTRIBUTION guide
- [x] I have signed-off my commits with git commit -s