### PR TITLE
fix: Scroll-position when navigating across pages

### DIFF
--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -1,9 +1,18 @@
 <script lang="ts">
+	import { afterNavigate } from '$app/navigation';
+
 	import '../../app.css';
 	import Footer from '$lib/footer.svelte';
 	import { Sidebar } from '$lib/components';
 	import type { LayoutData } from './$types';
 	export let data: LayoutData;
+
+	afterNavigate(() => {
+		const main = window.document.getElementById('svelte');
+		if (main) {
+			main.scrollIntoView();
+		}
+	});
 </script>
 
 {#if data.user}
@@ -15,3 +24,4 @@
 		<Footer />
 	</main>
 {/if}
+<!--  -->

--- a/src/routes/(marketing)/+layout.svelte
+++ b/src/routes/(marketing)/+layout.svelte
@@ -1,12 +1,19 @@
 <script lang="ts">
 	import '../../app.css';
 	import { onMount } from 'svelte';
-	import { goto } from '$app/navigation';
+	import { afterNavigate, goto } from '$app/navigation';
 	import type { LayoutServerData } from './$types';
 	import Footer from '$lib/footer.svelte';
 	import Navbar from '$lib/navbar.svelte';
 	import { page } from '$app/stores';
 	export let data: LayoutServerData;
+
+	afterNavigate(() => {
+		const main = window.document.getElementById('svelte');
+		if (main) {
+			main.scrollIntoView();
+		}
+	});
 
 	onMount(() => {
 		if (data.isAuthenticated && data.user && data.pathname === '/') {


### PR DESCRIPTION
### Motivation & Context:

When navigating across web-app, the scroll-position is not reset unless the page is reloaded. This is due to an existing [svelte issue](https://github.com/sveltejs/kit/issues/2733). Workaround -  scrollToView() added in the +layout.svelte files.
It seems to work fine now.

### Description:
Reset scroll position while navigating pages

### Types of Changes:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### PR Checklist:

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I've read the CONTRIBUTION guide
- [x] I have signed-off my commits with git commit -s