### PR TITLE
fix: Text color for supporting text

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -25,7 +25,7 @@ body {
 }
 
 a {
-	color: rgb(115, 115, 255);
+	color: rgb(72, 72, 188);
 	text-decoration: none;
 }
 
@@ -34,7 +34,7 @@ a:hover {
 }
 
 a:visited {
-	color: rgb(47, 47, 125);
+	color: rgb(25, 25, 92);
 }
 
 label {

--- a/src/lib/components/hero.svelte
+++ b/src/lib/components/hero.svelte
@@ -53,7 +53,7 @@
 				A Decentralised Container Registry
 			</span>
 
-			<p class="mt-5 break-words text-base text-primary-600 md:text-xl">
+			<p class="mt-5 break-words text-base text-slate-700 md:text-xl">
 				OpenRegistry is an open source container registry developed for people by people. Backed by
 				amazing distributed communities, OpenRegistry offers all the features of a container
 				registry along with awesome additions like automated build system
@@ -87,7 +87,7 @@
 
 	<div class="flex flex-col justify-center items-center gap-9 pt-10 pb-20">
 		<div
-			class="flex flex-col items-center justify-center text-center text-base text-primary-600 lg:text-lg px-9"
+			class="flex flex-col items-center justify-center text-center text-base text-slate-700 lg:text-lg px-9"
 		>
 			<span>
 				Browse, Pull, Push and Share 100s of container images by open source projects, software

--- a/src/lib/components/high-level-architecture.svelte
+++ b/src/lib/components/high-level-architecture.svelte
@@ -4,7 +4,7 @@
 	import Arrow from '$lib/icons/arrow-r.svelte';
 </script>
 
-<Card class="bg-primary-100 block py-12 lg:py-20 flex flex-col gap-6">
+<Card class="bg-primary-100 py-12 lg:py-20 flex flex-col gap-6">
 	<div class="flex px-6 w-full flex-col justify-center max-w-2xl items-center">
 		<span
 			class="text-primary-600 text-center whitespace-nowrap font-bold pb-6 text-3xl lg:text-5xl"
@@ -12,7 +12,7 @@
 			High Level Architecture
 		</span>
 
-		<p class="text-center text-base lg:text-lg font-normal leading-normal text-primary-600">
+		<p class="text-center text-base lg:text-lg font-normal leading-normal text-slate-800">
 			The following diagram tries to depict the high level architecture of OpenRegistry. We are
 			hosted on Akash dCloud and the container images are stored on decentralised storage systems
 			like IPFS. OpenRegistry is designed as a pluggable platform to adapt to any modern
@@ -22,7 +22,7 @@
 
 		<div class="flex cursor-pointer justify-center pt-2">
 			<a
-				class="mt-1 text-lg font-semibold text-primary-400"
+				class="mt-1 text-lg font-semibold text-primary-500"
 				href="https://blog.openregistry.dev/posts/overview"
 				target="_blank"
 				rel="noreferrer">More</a
@@ -31,7 +31,7 @@
 				class="transition-all duration-500 ease-in-out bg-transparent hover:transform hover:translate-x-2
             			hover:scale-110 border border-none w-5 p-1 mt-0.5"
 			>
-				<Arrow class="text-primary-400" />
+				<Arrow class="text-primary-500" />
 			</IconButton>
 		</div>
 	</div>

--- a/src/lib/components/how-to-intro.svelte
+++ b/src/lib/components/how-to-intro.svelte
@@ -31,21 +31,21 @@
 					<span class="text-3xl lg:text-5xl font-bold text-primary-600">
 						A truly decentralized container registry
 					</span>
-					<span class="text-lg lg:text-xl font-medium text-primary-600">
+					<span class="text-lg lg:text-xl font-medium text-slate-600">
 						in just a few simple steps, you can get started with OpenRegsitry
 					</span>
 
 					<ul class="text-center font-normal list-disc ml-6 mt-4">
-						<li class="text-left text-primary-600 text-base xl:text-xl">
+						<li class="text-left text-slate-600 text-base xl:text-xl">
 							Create an account on
 							<a href="https://OpenRegistry.dev/?signup=true" class="underline text-primary-600">
 								OpenRegistry.dev
 							</a>
 						</li>
-						<li class="text-left text-primary-600 text-base xl:text-xl">
+						<li class="text-left text-slate-600 text-base xl:text-xl">
 							Install Docker/Nerdctl/Podman
 						</li>
-						<li class="text-left text-primary-600 text-base xl:text-xl">
+						<li class="text-left text-slate-600 text-base xl:text-xl">
 							Login into OpenRegistry using Docker CLI
 						</li>
 					</ul>
@@ -86,7 +86,7 @@
 				bg-slate-100 p-4 aspect-square max-w-[420px]"
 			>
 				<LaboratoryIcon />
-				<span class="text-center text-primary-600 text-base lg:text-lg"
+				<span class="text-center text-slate-700 text-base lg:text-lg"
 					>The container image subitted by user is divided into 1 or more layers depending on a few
 					factors like size.</span
 				>
@@ -97,7 +97,7 @@
 				bg-slate-100 p-4 aspect-square max-w-[420px]"
 			>
 				<LayersIcon />
-				<span class="text-center text-primary-600 text-base lg:text-lg"
+				<span class="text-center text-slate-700 text-base lg:text-lg"
 					>The layers are further divided into blobs and sequentially uploaded to the storage
 					backend of user's preference like IPFS or Storj</span
 				>
@@ -108,7 +108,7 @@
 				bg-slate-100 p-4 aspect-square max-w-[420px]"
 			>
 				<CloudIcon />
-				<span class="text-center text-primary-600 text-base lg:text-lg"
+				<span class="text-center text-slate-700 text-base lg:text-lg"
 					>A resolver component uploads the blobs to IPFS/Stoj and brings back the content hash
 					which is mapped to the container image</span
 				>
@@ -119,7 +119,7 @@
 				bg-slate-100 p-4 aspect-square max-w-[420px]"
 			>
 				<ConfirmIcon />
-				<span class="text-center text-primary-600 text-base lg:text-lg"
+				<span class="text-center text-slate-700 text-base lg:text-lg"
 					>Once all the blobs for a layer are recieved,a digest is calculated which is used with
 					content hash while retrival of the layer</span
 				>

--- a/src/lib/components/invite.svelte
+++ b/src/lib/components/invite.svelte
@@ -33,10 +33,10 @@
 	};
 </script>
 
-<div class="px-10 py-10 z-50">
+<div class="flex justify-center items-center w-full px-3 py-3">
 	<form
 		on:submit|preventDefault={() => sendInvites()}
-		class="flex justify-around items-center gap-8 flex-col h-full w-full"
+		class="flex justify-center items-center gap-8 flex-col h-full w-full"
 	>
 		<span class="text-2xl capitalize font-semibold text-primary-500">Invite Your Colleauges</span>
 		<div class="w-full">

--- a/src/lib/components/overview.svelte
+++ b/src/lib/components/overview.svelte
@@ -20,7 +20,7 @@
 				>
 					Overview
 				</span>
-				<p class="text-base lg:text-lg text-primary-700 text-center font-normal">
+				<p class="text-base lg:text-lg text-slate-800 text-center font-normal">
 					OpenRegistry is fully compliant with OCI(Open Container Initiative) Distribution
 					Specification and has received an official certification from OCI. This means there is no
 					difference in operations of OpenRegistry than any other popular container registries like
@@ -45,7 +45,7 @@
 				</p>
 				<div class="flex justify-center pt-2 cursor-pointer">
 					<a
-						class="text-primary-400 font-medium text-lg mt-1"
+						class="text-primary-500 font-medium text-lg mt-1 hover:no-underline"
 						href="https://conformance.opencontainers.org/"
 						target="_blank"
 						rel="noreferrer">More</a
@@ -54,7 +54,7 @@
 						class="transition-all duration-500 ease-in-out bg-transparent hover:transform hover:translate-x-2
             			hover:scale-110 border border-none w-5 p-1 mt-0.5"
 					>
-						<Arrow class="text-primary-400" />
+						<Arrow class="text-primary-500" />
 					</IconButton>
 				</div>
 			</div>
@@ -69,8 +69,8 @@
 					Collaborations
 				</span>
 				<p
-					class="text-base lg:text-lg text-primary-700 text-center font-normal
-					leading-6 tracking-wide"
+					class="text-base lg:text-lg text-slate-800 text-center font-normal 
+					leading-6 tracking-wide "
 				>
 					Want to Collaborate? It's super easy with OpenRegistry. Our code is OpenSource and free to
 					use. We are open to collaborations with projects that share similar vision and can be
@@ -92,7 +92,7 @@
 				</p>
 				<div class="flex justify-center pt-2 cursor-pointer">
 					<a
-						class="text-primary-400 text-lg mt-1 font-medium"
+						class="text-primary-500 text-lg mt-1 font-medium hover:no-underline"
 						href="https://blog.openregistry.dev/posts/collaborations"
 						target="_blank"
 						rel="noreferrer">More</a
@@ -101,7 +101,7 @@
 						class="transition-all duration-500 ease-in-out bg-transparent hover:transform hover:translate-x-2
             			hover:scale-110 border border-none w-5 p-1 mt-0.5"
 					>
-						<Arrow class="text-primary-400" />
+						<Arrow class="text-primary-500" />
 					</IconButton>
 				</div>
 			</div>
@@ -126,7 +126,7 @@
 					</span>
 				</div>
 
-				<p class="text-base lg:text-lg text-primary-700 text-center font-normal">
+				<p class="text-base lg:text-lg text-slate-800 text-center font-normal">
 					Web 3.0 is the internet's layer of trust. It offers the decentralisation from web 1.0 and
 					richness of web 2.0. It's Trustless, Self-Governing, Distributed and many more things. We
 					at OpenRegistry believe in dWorld full of dApps. With our initiative, we want to make
@@ -134,7 +134,7 @@
 				</p>
 				<div class="flex justify-center pt-2 cursor-pointer">
 					<a
-						class="text-primary-400 text-lg mt-1 font-medium"
+						class="text-primary-500 text-lg mt-1 font-medium hover:no-underline"
 						href="https://blog.openregistry.dev/posts/web3-infrastructure"
 						target="_blank"
 						rel="noreferrer">More</a
@@ -143,7 +143,7 @@
 						class="transition-all duration-500 ease-in-out bg-transparent hover:transform hover:translate-x-2
             			hover:scale-110 border border-none w-5 p-1 mt-0.5"
 					>
-						<Arrow class="text-primary-400" />
+						<Arrow class="text-primary-500" />
 					</IconButton>
 				</div>
 			</div>

--- a/src/lib/components/sidebar.svelte
+++ b/src/lib/components/sidebar.svelte
@@ -206,36 +206,36 @@
 								href="/about"
 								class="flex flex-row gap-3 justify-start items-center text-slate-700 tracking-wide text-lg py-2.5
 							hover:bg-slate-100 hover:shadow-2xl hover:no-underline"
-							>
-								<HeartIcon class="" />
-								<span>About us</span>
-							</a>
-							<a
-								href="https://github.com/containerish/OpenRegistry"
-								target="_blank"
-								rel="noreferrer"
-								class="flex flex-row gap-3 justify-start items-center text-slate-700 tracking-wide text-lg py-2.5
+						>
+							<HeartIcon class="" />
+							<span>About us</span>
+						</a>
+						<a
+							href="https://github.com/containerish/OpenRegistry"
+							target="_blank"
+							rel="noreferrer"
+							class="flex flex-row gap-3 justify-start items-center text-slate-700 tracking-wide text-lg py-2.5
 							 hover:bg-slate-100 hover:shadow-2xl hover:no-underline"
-							>
-								<StarIcon class="w-6 h-6 " />
-								<span>Star us on Github</span>
-							</a>
-							<a
-								href="#"
-								on:click={toggleModal}
-								class="bg-transparent border-0 flex flex-row gap-3 justify-start items-center text-slate-700 tracking-wide
+						>
+							<StarIcon class="w-6 h-6 " />
+							<span>Star us on Github</span>
+						</a>
+						<a
+							href="#"
+							on:click={toggleModal}
+							class="bg-transparent border-0 flex flex-row gap-3 justify-start items-center text-slate-700 tracking-wide
 							text-lg py-2.5 hover:bg-slate-100 hover:shadow-2xl
 							hover:no-underline"
-							>
-								<UserPlusIcon class="" />
-								<span>Invite People</span>
-							</a>
-						</div>
-						<hr />
-						<div class="flex flex-col gap-3.5">
-							<a
-								href="/u"
-								class="flex flex-row gap-3 justify-start items-center text-slate-700 tracking-wide text-lg
+						>
+							<UserPlusIcon class="" />
+							<span>Invite People</span>
+						</a>
+					</div>
+					<hr />
+					<div class="flex flex-col gap-3.5">
+						<a
+							href="/u"
+							class="flex flex-row gap-3 justify-start items-center text-slate-700 tracking-wide text-lg
                      py-2.5 hover:bg-slate-100 hover:shadow-2xl hover:no-underline"
 							>
 								<ProfileIcon class="text-slate-700 h-6 w-6 " />
@@ -254,21 +254,20 @@
 					</div>
 				</div>
 
-				<div
-					class="flex flex-row justify-start items-center gap-4 text-slate-700 tracking-wide text-lg font-medium"
-				>
-					<div class="w-fit border-2 border-primary-300 p-2 rounded-full">
-						<UserIcon class="h-6 w-6" />
-					</div>
-					<div class="flex flex-col">
-						<span>{user.username}</span>
-						<span>{user.email}</span>
-					</div>
+			<div
+				class="flex flex-row justify-start items-center gap-4 text-slate-700 tracking-wide text-lg font-medium"
+			>
+				<div class="w-fit border-2 border-primary-300 p-2 rounded-full">
+					<UserIcon class="h-6 w-6" />
 				</div>
-				<button
-					aria-label="signout button"
-					formaction="/?/signout"
-					class=" border-0 bg-transparent flex flex-row gap-3 justify-start items-center text-slate-700 tracking-wide text-lg
+				<div class="flex flex-col">
+					<span>{user.username}</span>
+					<span>{user.email}</span>
+				</div>
+			</div>
+			<button
+				formaction="/?/signout"
+				class=" border-0 bg-transparent flex flex-row gap-3 justify-start items-center text-slate-700 tracking-wide text-lg
 		        py-3 hover:bg-slate-50 hover:shadow-2xl hover:no-underline"
 				>
 					<SignOutIcon class="" />
@@ -295,9 +294,9 @@
 			</label>
 		</form>
 		{#if showModal}
-			<Modal>
+			<Dialog>
 				<Invite handleModal={toggleModal} />
-			</Modal>
+			</Dialog>
 		{/if}
 	{/if}
 </div>

--- a/src/routes/(app)/apps/github/connect/all-deployments/+page.svelte
+++ b/src/routes/(app)/apps/github/connect/all-deployments/+page.svelte
@@ -23,7 +23,7 @@
 </svelte:head>
 
 <div class="w-full p-20">
-	<TabGroup defaultIndex={1}>
+	<TabGroup defaultIndex={0}>
 		<TabList class="text-lg flex gap-9 ml-2 border-b-2 border-slate-300">
 			<Tab let:selected class={handleTabSelect}>Builds</Tab>
 			<Tab class={handleTabSelect}>Settings</Tab>

--- a/src/routes/(app)/apps/github/connect/all-deployments/settings.svelte
+++ b/src/routes/(app)/apps/github/connect/all-deployments/settings.svelte
@@ -9,7 +9,7 @@
 	};
 </script>
 
-<TabGroup defaultIndex={2} class="grid grid-cols-4 gap-9 px-3 py-9">
+<TabGroup defaultIndex={0} class="grid grid-cols-4 gap-9 px-3 py-9">
 	<TabList class="col-span-1 flex flex-col w-full">
 		<Tab class={handleSettingsTab}>General</Tab>
 		<Tab class={handleSettingsTab}>Builds and Deployments</Tab>

--- a/src/routes/(app)/apps/github/connect/setup/select-repo.svelte
+++ b/src/routes/(app)/apps/github/connect/setup/select-repo.svelte
@@ -98,11 +98,11 @@
 					<button
 					aria-label="repository"
 						on:click={() => handleRepoSelect(repo)}
-						class="bg-white text-slate-700 text-sm lg:text-base rounded border-2 gap-2 border-primary-100
+						class="text-slate-700 text-sm lg:text-base rounded border-2 gap-2 border-primary-100 
 						flex justify-center items-center py-2 lg:py-3 hover:shadow-2xl {repo.repository.name ===
 						selectedRepo
-							? 'bg-primary-100 shadow-2xl shadow-primary-300'
-							: ''}"
+							? 'shadow-2xl shadow-primary-200 bg-primary-50'
+							: 'bg-white'}"
 					>
 						{repo.repository.name}
 						{#if repo.repository.name === selectedRepo}

--- a/src/routes/(app)/search/+page.svelte
+++ b/src/routes/(app)/search/+page.svelte
@@ -109,7 +109,7 @@
 				: 'justify-center'} flex items-center w-full h-full max-w-[3000px]"
 		>
 			{#if showTooltip}
-				<div id="tooltip" class="z-50 bg-cyan-200 rounded py-3 px-4" use:popperContent={extraOpts}>
+				<div id="tooltip" class=" bg-cyan-200 rounded py-3 px-4" use:popperContent={extraOpts}>
 					<span class=" text-slate-800">
 						Coming soon
 						<svg

--- a/src/routes/(app)/u/[username]/[repo]/+page.svelte
+++ b/src/routes/(app)/u/[username]/[repo]/+page.svelte
@@ -72,7 +72,7 @@
 		<div class="w-full text-slate-700">
 			<div class="flex gap-4 items-center">
 				<span class="text-2xl lg:text-4xl">{data.username}/{data.repo}</span>
-				<IconButton class="mt-3 w-2">
+				<IconButton class="mt-3 w-3">
 					<Star class="w-5 h-5 lg:w-8 lg:h-8" />
 				</IconButton>
 			</div>

--- a/src/routes/(marketing)/about/+page.svelte
+++ b/src/routes/(marketing)/about/+page.svelte
@@ -22,14 +22,14 @@
 			class="flex flex-col gap-1 lg:gap-8 justify-start min-h-[1000px] items-center text-center px-10
 			py-6 mx-5 my-3 max-w-[600px] lg:max-w-max"
 		>
-			<div>
+			<div class="max-w-5xl">
 				<h1 class="text-3xl lg:text-5xl font-semibold text-primary-600">
 					Decentralisation is the Future!
 				</h1>
 				<h1 class="text-3xl lg:text-5xl font-semibold text-primary-600 mb-8">
 					and we want to play a role in making it better
 				</h1>
-				<span class="text-base lg:text-lg text-slate-700">
+				<span class="text-base lg:text-lg text-slate-800">
 					Our Vision is derived and powered by the principals of Web 3.0 and Dworld of Dapps. With
 					increasing awareness and adaption of distributed network, the worlds are moving towards a
 					better future for everyone. OpenRegistry is an effort to bring a change with community's
@@ -37,8 +37,8 @@
 					promise of scalability, reliability and transparency.
 				</span>
 			</div>
-			<div>
-				<span class="text-base lg:text-lg text-slate-700">
+			<div class="max-w-5xl">
+				<span class="text-base lg:text-lg text-slate-800">
 					We started off as a fun project which eventually opened many doors for us. Although we are
 					a small team, we are Passionate about what we do. We have learned, built and evolved our
 					careers with help of OpenSource projects. With OpenRegistry, we want to built yet another
@@ -46,14 +46,14 @@
 				</span>
 			</div>
 
-			<span class="text-3xl lg:text-4xl font-semibold text-primary-500 mt-14">
+			<span class="text-3xl lg:text-4xl font-semibold text-primary-600 mt-14">
 				Get to know our Team
 			</span>
 			<div class="flex flex-col gap-20 mt-8 w-full">
 				<div class="flex justify-center">
 					<div class="flex flex-col gap-4 px-4 lg:px-12 py-8 bg-white rounded-sm shadow-3xl">
 						<div class="flex flex-col">
-							<span class="text-xl font-semibold text-slate-700 capitalize"> Jasdeep Singh </span>
+							<span class="text-xl font-semibold text-primary-500 capitalize"> Jasdeep Singh </span>
 
 							<p class=" text-slate-700 capitalize">Engineer</p>
 						</div>
@@ -92,7 +92,7 @@
 				<div class="flex justify-center">
 					<div class="flex flex-col gap-4 px-4 lg:px-12 py-8 bg-white rounded-sm shadow-3xl">
 						<div class="flex flex-col">
-							<span class="text-xl font-semibold text-slate-700 capitalize"> Gunjan Valecha </span>
+							<span class="text-xl font-semibold text-primary-500 capitalize"> Gunjan Valecha </span>
 							<p class="text-slate-700 capitalize">Engineer</p>
 						</div>
 


### PR DESCRIPTION
### Motivation & Context:

Most of the text on home page was blue and I wasn't very sure about it. The Coloured text should only be used for links and the parts of text we want to grab more attention to. With all the text being blue, it was defeating the whole purpose.
This PR tries to fix it by making most text gray and leaving Headings and links blue

### Description:
Changed text color to gray for most parts except headings

### Types of Changes:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### PR Checklist:

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I've read the CONTRIBUTION guide
- [x] I have signed-off my commits with git commit -s