### PR TITLE
fix: Webauthn login

### DIFF
--- a/src/hooks.client.ts
+++ b/src/hooks.client.ts
@@ -1,0 +1,9 @@
+import type { HandleClientError } from '@sveltejs/kit';
+
+export const handleError: HandleClientError = async ({ error, event }) => {
+	console.log('unhandled client exception - route: %s - error: %s', event.route.id, error);
+
+	return {
+		message: typeof error === 'string' ? error : JSON.stringify(error)
+	};
+};

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,5 +1,6 @@
 import { session } from './stores/session';
-import { redirect, type Handle } from '@sveltejs/kit';
+import { redirect } from '@sveltejs/kit';
+import type { Handle, HandleServerError } from '@sveltejs/kit';
 import { createConnectTransport } from '@bufbuild/connect-web';
 import { createPromiseClient } from '@bufbuild/connect';
 import { GitHubActionsLogsService } from '@buf/containerish_openregistry.bufbuild_connect-es/services/kon/github_actions/v1/build_logs_connect';
@@ -61,3 +62,10 @@ export const handle = sequence(
 	authenticationHandler,
 	createProtobufClient
 );
+
+export const handleError: HandleServerError = async ({ error, event }) => {
+	console.log('unhandled server exception - route: %s - error: %s', event.route.id, error);
+	return {
+		message: typeof error === 'string' ? error : JSON.stringify(error)
+	};
+};

--- a/src/lib/types/webauthn.ts
+++ b/src/lib/types/webauthn.ts
@@ -1,5 +1,6 @@
 import type { WebAuthnSignInSchema, WebAuthnSignUpSchema } from '$lib/formSchemas';
 import type {
+	AuthenticationPublicKeyCredential,
 	CredentialCreationOptionsJSON,
 	CredentialRequestOptionsJSON
 } from '@github/webauthn-json/browser-ponyfill';
@@ -34,4 +35,9 @@ export type WebAuthnBeginLoginResponseType = WebAuthnError & {
 };
 export type WebAuthnFinishLoginResponseType = WebAuthnError & {
 	message?: string;
+};
+
+export type WebAuthnFinishLoginRequestType = {
+	credentials: AuthenticationPublicKeyCredential;
+	username: string;
 };

--- a/src/routes/(marketing)/auth/signin/+page.svelte
+++ b/src/routes/(marketing)/auth/signin/+page.svelte
@@ -21,7 +21,7 @@
 	let password = $page.form?.data?.password as string;
 	let showForgotPasswordForm = false;
 	let formMsg: string;
-    let forgotPwdMessage = ''
+	let forgotPwdMessage = '';
 
 	const handleForgotPassword: SubmitFunction = () => {
 		isLoading = true;
@@ -30,7 +30,7 @@
 			switch (result.type) {
 				case 'success':
 					await update();
-					forgotPwdMessage = result.data?.message ?? 'Please check your inbox'
+					forgotPwdMessage = result.data?.message ?? 'Please check your inbox';
 					isLoading = false;
 					break;
 				case 'failure':
@@ -42,7 +42,7 @@
 					// handle server side error here
 					await update();
 					await applyAction(result);
-                    break;
+					break;
 				default:
 					await update();
 			}
@@ -50,7 +50,7 @@
 		};
 	};
 
-    let isSigninDisabled = false;
+	let isSigninDisabled = false;
 	const handleSignInSubmit: SubmitFunction = () => {
 		isLoading = true;
 
@@ -64,14 +64,14 @@
 					// handle error here
 					await applyAction(result);
 					await update();
-                    isSigninDisabled = true
+					isSigninDisabled = true;
 					break;
 				case 'error':
 					// handle server side error here
 					await update();
 					await applyAction(result);
-                    isSigninDisabled = true
-                    break;
+					isSigninDisabled = true;
+					break;
 				default:
 					await update();
 			}
@@ -106,6 +106,7 @@
 			goto('/repositories', { invalidateAll: true });
 			return;
 		} catch (err) {
+			console.log('error in webauthn login: ', err);
 			if (err instanceof ZodError) {
 				isLoading = false;
 				const zError = err.flatten();
@@ -113,6 +114,8 @@
 				webAuthnForm.formErrors = [...zError.formErrors];
 				return;
 			}
+            webAuthnForm.formErrors = [(err as Error).message]
+			isLoading = false;
 		}
 	};
 
@@ -144,19 +147,21 @@
 				<span class="text-start text-primary-500 text-3xl font-semibold">
 					Log in to your account</span
 				>
-                <form 
-                class="mt-2 flex flex-col gap-4" 
-                method="POST" 
-                action="/auth/signin?/signin" 
-                use:enhance={handleSignInSubmit}
-                >
+				<form
+					class="mt-2 flex flex-col gap-4"
+					method="POST"
+					action="/auth/signin?/signin"
+					use:enhance={handleSignInSubmit}
+				>
 					<div class="">
 						<Textfield
 							errors={$page.form?.errors?.email}
 							name="email"
 							label="Email"
 							type="text"
-                            on:input={() => {isSigninDisabled = false}}
+							on:input={() => {
+								isSigninDisabled = false;
+							}}
 							value={$page.form?.data?.email || ''}
 						/>
 					</div>
@@ -166,7 +171,9 @@
 							name="password"
 							label="Password"
 							type="password"
-                            on:input={() => {isSigninDisabled = false}}
+							on:input={() => {
+								isSigninDisabled = false;
+							}}
 							value={password}
 						/>
 					</div>
@@ -181,8 +188,8 @@
 
 					<div class="mt-4 flex w-full justify-center space-x-5">
 						<ButtonSolid disabled={isSigninDisabled} class="w-full" {isLoading}>
-                            Sign In
-                        </ButtonSolid>
+							Sign In
+						</ButtonSolid>
 					</div>
 
 					<ButtonOutlined on:click={handleIsWebAuthn} class="gap-0">
@@ -252,12 +259,12 @@
 			{/if}
 
 			{#if showForgotPasswordForm}
-				<form 
-                method="POST" 
-                action="/auth/signin?/forgotPassword" 
-                id="reset_password" 
-                use:enhance={handleForgotPassword}
-                >
+				<form
+					method="POST"
+					action="/auth/signin?/forgotPassword"
+					id="reset_password"
+					use:enhance={handleForgotPassword}
+				>
 					<div class="">
 						{#if !formMsg}
 							<div class="flex flex-col items-start gap-6 px-1">
@@ -274,24 +281,24 @@
 								</label>
 							</div>
 
-						<Textfield errors={$page.form?.errors?.email} name="email" bind:value={email} />
+							<Textfield errors={$page.form?.errors?.email} name="email" bind:value={email} />
 						{/if}
 					</div>
 
-				{#if $page.form?.formErrors && $page.form?.formErrors.length}
-					<div class="w-full pt-1 text-center">
-						<span class="text-center text-xs font-semibold capitalize text-red-600">
-							{$page.form?.formErrors[0]}
-						</span>
-					</div>
-				{/if}
+					{#if $page.form?.formErrors && $page.form?.formErrors.length}
+						<div class="w-full pt-1 text-center">
+							<span class="text-center text-xs font-semibold capitalize text-red-600">
+								{$page.form?.formErrors[0]}
+							</span>
+						</div>
+					{/if}
 					<div class="mt-9 flex w-full justify-center flex-col gap-3">
-                        {#if forgotPwdMessage}
-                            <span class=" text-emerald-700">{forgotPwdMessage.charAt(0).toUpperCase() + forgotPwdMessage.slice(1)}</span>
-                        {/if}
-						<ButtonSolid disabled={!!emailErr} {isLoading}>
-							Submit
-						</ButtonSolid>
+						{#if forgotPwdMessage}
+							<span class=" text-emerald-700"
+								>{forgotPwdMessage.charAt(0).toUpperCase() + forgotPwdMessage.slice(1)}</span
+							>
+						{/if}
+						<ButtonSolid disabled={!!emailErr} {isLoading}>Submit</ButtonSolid>
 						<IconButton
 							on:click={handleBackToMain}
 							class="text-primary-400 text-sm w-full p-0 flex justify-center"

--- a/src/routes/apis/webauthn/finish-login/+server.ts
+++ b/src/routes/apis/webauthn/finish-login/+server.ts
@@ -1,0 +1,71 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { env } from '$env/dynamic/public';
+import { parse, splitCookiesString } from 'set-cookie-parser';
+import type { WebAuthnFinishLoginRequestType } from '$lib/types/webauthn';
+
+export const POST: RequestHandler = async ({ fetch, request, cookies }) => {
+	let body: WebAuthnFinishLoginRequestType;
+	try {
+		body = (await request.json()) as WebAuthnFinishLoginRequestType;
+	} catch (err) {
+		return json({ error: err }, { status: 400 });
+	}
+
+	const url = new URL('/auth/webauthn/login/finish', env.PUBLIC_OPEN_REGISTRY_BACKEND_URL);
+	url.searchParams.set('username', body.username);
+	try {
+		const response = await fetch(url, {
+			method: 'POST',
+			body: JSON.stringify(body.credentials)
+		});
+		if (!response.ok) {
+			const data = (await response.json()) as { message: string; error: string };
+			return json(
+				{ error: { code: response.status, message: data.message } },
+				{ status: response.status }
+			);
+		}
+
+		const responseCookies = response.headers.get('set-cookie');
+		if (!responseCookies) {
+			return json(
+				{ errro: { code: 401, message: 'Received invalid response from server' } },
+				{ status: 401 }
+			);
+		}
+		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+		const cookieList = parse(splitCookiesString(responseCookies), {
+			silent: true,
+			decodeValues: true
+		});
+
+		cookieList.forEach((cookie) => {
+			cookies.set(cookie.name, cookie.value, {
+				domain: cookie.domain,
+				httpOnly: cookie.httpOnly,
+				sameSite: getSameSite(cookie.sameSite),
+				secure: cookie.secure,
+				path: '/',
+				expires: cookie.expires
+			});
+		});
+
+		return json((await response.json()) as { message: string }, { status: 200 });
+	} catch (err) {
+		return json({ error: { code: 500, message: (err as Error).message } }, { status: 500 });
+	}
+};
+
+const getSameSite = (sameSite?: string) => {
+	switch (sameSite) {
+		case 'lax':
+			return sameSite;
+		case 'strict':
+			return sameSite;
+		case 'none':
+			return 'none';
+		default:
+			return 'lax';
+	}
+};


### PR DESCRIPTION
### Motivation & Context:

WebAuthn login was failing on Cloudflare Pages because on Cloudflare, `credentials: include` options is not supported in fetch. This means the cookies are not set from the response as they usually are.

### Description:

In this PR, we move the `WebAuth - Finish Login` operation to the server, & set the cookies manually from the response

### Types of Changes:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### PR Checklist:

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I've read the CONTRIBUTION guide
- [x] I have signed-off my commits with git commit -s