### PR TITLE
fix: Animation for Repobox tiles

### DIFF
--- a/src/lib/components/repo-box.svelte
+++ b/src/lib/components/repo-box.svelte
@@ -18,8 +18,9 @@
 				stagger: 0.1,
 				ease: backInOut,
 				scrollTrigger: {
-					trigger: '.browse',
-					start: 'top center'
+					trigger: '.repobox',
+					start: 'top center',
+					id: 'tile'
 				}
 			}
 		);


### PR DESCRIPTION
### Motivation & Context:

The repotile animation was not being triggered without a little scroll. This did not look good for larger screens when it stayed blank until the scroll was triggered. This PR changes the trigger, the trigger now is repobox itself (earlier it was the container that has all the repo tiles). This helps as the animation triggers as soon as the tiles are in view

### Description:

\Animation for repotiles

### Types of Changes:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### PR Checklist:

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I've read the CONTRIBUTION guide
- [x] I have signed-off my commits with git commit -s